### PR TITLE
RF: Use persistent remote shell

### DIFF
--- a/ria_remote/remote.py
+++ b/ria_remote/remote.py
@@ -258,7 +258,7 @@ class SSHRemoteIO(IOBase):
             )
             self.ssh.open()
             # open a remote shell
-            cmd = ['ssh'] + self.ssh._ctrl_options + [self.ssh.sshri.as_str()]
+            cmd = ['ssh'] + self.ssh._ssh_args + [self.ssh.sshri.as_str()]
             self.shell = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
             # swallow login message(s):
             self.shell.stdin.write(b"echo RIA-REMOTE-LOGIN-END\n")

--- a/ria_remote/remote.py
+++ b/ria_remote/remote.py
@@ -1,23 +1,16 @@
 from annexremote import SpecialRemote
 from annexremote import RemoteError
 
-import os.path as op
 from six import (
     text_type,
 )
 from pathlib import (
     Path,
-    PosixPath,
 )
 import shutil
 import tempfile
 from shlex import quote as sh_quote
 import subprocess
-from time import (
-    sleep,
-    time
-)
-
 import logging
 lgr = logging.getLogger('ria_remote')
 

--- a/ria_remote/tests/test_basics.py
+++ b/ria_remote/tests/test_basics.py
@@ -172,7 +172,7 @@ def test_version_check(path, objtree):
 
     # Now fake-change the version
     with open(str(remote_obj_tree_version_file), 'w') as f:
-        f.write('2')
+        f.write('2\n')
 
     # Now we should see a message about it
     with swallow_logs(new_level=logging.INFO) as cml:

--- a/ria_remote/tests/test_basics.py
+++ b/ria_remote/tests/test_basics.py
@@ -160,9 +160,9 @@ def test_version_check(path, objtree):
 
     # Currently the content of booth should be "1"
     with open(str(remote_ds_tree_version_file), 'r') as f:
-        eq_(f.read(), '1')
+        eq_(f.read().strip(), '1')
     with open(str(remote_obj_tree_version_file), 'r') as f:
-        eq_(f.read(), '1')
+        eq_(f.read().strip(), '1')
 
     # Accessing the remote should not yield any output regarding versioning, since it's the "correct" version
     # Note that "fsck" is an arbitrary choice. We need just something to talk to the special remote

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     datalad >= 0.12.0rc4
     annexremote
     future
+    fabric
 scripts =
   bin/git-annex-remote-ria
 test_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ install_requires =
     datalad >= 0.12.0rc4
     annexremote
     future
-    fabric
 scripts =
   bin/git-annex-remote-ria
 test_requires =


### PR DESCRIPTION
Use a persistent SSH shell and communicate via stdin/stdout rather than having separated calls via SHH. Although the latter would still share the connection it comes with a troublesome overhead per call, that (depending on infrastructure) might simply be not bearable.

Note, that we communicate with that in blocking mode here, since it seems doable and sufficient for what this special remote needs. Alternatives to that approach turn out to come with lots of issues each. 