### PR TITLE
ENH: error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ placing a snippet like this in `$HOME/.ssh/config`:
       Port 2222
       PreferredAuthentications publickey
 
+There are additional configurations available:
+
+- By default ria-remote will check the remote end's layout version by reading a `ria-layout-version` file at the 
+  toplevel (`base-path`) as well as at the individual dataset directories. If the layout version isn't known it will set 
+  its mode to "read-only" and will reject to write anything to that store in order to not accidentally mix up different 
+  layouts. This behavior can be overwriten by setting `annex.ria-remote.<name>.force-write` to `true`.
+- The remote end can be configured to write any occuring exception into a log file. This can be particularly helpful in 
+  case of some kind of a central storage used by multiple user to look into general issues. For this to be used, the
+  version recorded in that `ria-layout-version` file can be appended by `|l` (for logging). If done at the toplevel this 
+  will applied to all datasets. However, since that kind of log can potentially leak information one does not want to be 
+  leaked and the general notion of having a distributed system that can be configured by a remote side is problematic,
+  this configuration can be ignored by any client by setting `annex.ria-remote.<name>.ignore-remote-config`.       
 
 ## Support
 

--- a/ria_remote/remote.py
+++ b/ria_remote/remote.py
@@ -587,8 +587,8 @@ class RIARemote(SpecialRemote):
         file_content = self.io.read_file(path).strip().split('|')
         assert 1 <= len(file_content) <= 2, "invalid version file {}".format(path)
         remote_version = file_content[0]
-        remote_config_flags = file_content[1]
-        if not self.ignore_remote_config:
+        remote_config_flags = file_content[1] if len(file_content) == 2 else None
+        if not self.ignore_remote_config and remote_config_flags:
             # Note: 'or', since config flags can come from toplevel (dataset-tree-root) as well as
             #       from dataset-level.
             self.remote_log_enabled = self.remote_log_enabled or 'l' in remote_config_flags

--- a/ria_remote/remote.py
+++ b/ria_remote/remote.py
@@ -354,6 +354,12 @@ class SSHRemoteIO(IOBase):
         self.ssh.put(str(src), str(dst))
 
     def get(self, src, dst):
+
+        # Note, that as we are in blocking mode, we can't easily fail on the actual get (that is 'cat').
+        # Therefore check beforehand.
+        if not self.exists(src):
+            raise RIARemoteError("annex object {src} does not exist.".format(src=src))
+
         # TODO: see get_from_archive()
 
         # TODO: Currently we will hang forever if the file isn't readable and it's supposed size is bigger than whatever
@@ -419,6 +425,12 @@ class SSHRemoteIO(IOBase):
         return loc in out
 
     def get_from_archive(self, archive, src, dst):
+
+        # Note, that as we are in blocking mode, we can't easily fail on the actual get (that is 'cat').
+        # Therefore check beforehand.
+        if not self.exists(archive):
+            raise RIARemoteError("archive {arc} does not exist.".format(arc=archive))
+
 
         # TODO: We probably need to check exitcode on stderr (via marker). If archive or content is missing we will
         #       otherwise hang forever waiting for stdout to fill `size`

--- a/ria_remote/remote.py
+++ b/ria_remote/remote.py
@@ -488,11 +488,12 @@ def handle_errors(func):
         except Exception as e:
             if self.remote_log_enabled:
                 from datetime import datetime
-
+                from traceback import format_exc
+                exc_str = format_exc()
+                entry = "{time}: Error:\n{exc_str}\n".format(time=datetime.now(),
+                                                                exc_str=exc_str)
                 log_target = self.objtree_base_path / 'error_logs' / "{dsid}.{uuid}.log".format(dsid=self.archive_id,
                                                                                                 uuid=self.uuid)
-                entry = "{time}: {error}".format(time=datetime.now(),
-                                                 error=str(e))
                 self.io.write_file(log_target, entry, mode='a')
             if not isinstance(e, RIARemoteError):
                 raise RIARemoteError(str(e))

--- a/ria_remote/remote.py
+++ b/ria_remote/remote.py
@@ -823,9 +823,10 @@ class RIARemote(SpecialRemote):
     def whereis(self, key):
         dsobj_dir, archive_path, key_path = self._get_obj_location(key)
         return str(key_path) if self._local_io() \
-            else '{}:{}'.format(
+            else '{}: {}:{}'.format(
                 self.storage_host,
-                sh_quote(str(key_path)),  # TODO: Shouldn't we report the entire path (i.e. dsobj_dir + key_path)?  => dspath:keypath
+                self.remote_git_dir,
+                sh_quote(str(key_path)),
         )
 
     @staticmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,12 @@
 [metadata]
 url = https://github.com/datalad/git-annex-ria-remote
-author =
-    Michael Hanke
-    Benjamin Poldrack
-author_email =
-    michael.hanke@gmail.com
-    benjaminpoldrack@gmail.com
-maintainer =
-    Michael Hanke
-    Benjamin Poldrack
-maintainer_email =
-    michael.hanke@gmail.com
-    benjaminpoldrack@gmail.com
+author = Benjamin Poldrack
+author_email =  benjaminpoldrack@gmail.com
+maintainer = Benjamin Poldrack
+maintainer_email =  benjaminpoldrack@gmail.com
 description = Git-annex special remote implementation for (remote) indexed archives
 long_description = file:README.md
-long_description_content_type = text/markdown; charset=UTF-8
+long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
 license = MIT
 classifiers =
     Programming Language :: Python


### PR DESCRIPTION
Introduce a remote side logging of Exceptions, that can be configured on the remote end but forcefully ignored by the client side to avoid being forced to potentially leak anything to a remote.

Additionally have a more convenient way of dealing with Exceptions via a decorator. Note, that we need to convert every exception to a `RemoteError` in order to report on it via annex. Otherwise it will spit out things on `stdout`, which then leads to break the communication with annex. (resulting in a "broken pipe" rather than an actual error message). Furthermore annex lets us report one line only that way.

One thing to be done:
- [x] include traceback in the log file