### PR TITLE
RM: remove  future  module from dependencies -- should not be needed or used (>= 3.5)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ python_requires = >= 3.5
 install_requires =
     datalad >= 0.12.0rc6
     annexremote
-    future
 scripts =
   bin/git-annex-remote-ria
 test_requires =


### PR DESCRIPTION
may be tests would show that it was somehow needed?