### PR TITLE
Fix dependency - ria-install is broken with datalad 0.12

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include ria_remote/_version.py
+recursive-include ria_remote/resources *

--- a/ria_remote/install.py
+++ b/ria_remote/install.py
@@ -135,10 +135,3 @@ class Install(Clone):
         if reckless:
             proc_args.append('reckless')
         target_ds.run_procedure(proc_args)
-
-        #
-        # TODO configure dataset to run this procedure after
-        # every get/install of a subdataset
-        # TODO enhance datalad to trigger it whenever it seen
-        # an action:install;status:ok result
-        #

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
-    datalad >= 0.12.0rc6
+    datalad == 0.12.0rc6
     annexremote
     future
 scripts =


### PR DESCRIPTION
Currently ria-install relies on clone implementation of datalad 0.12.0rc6. We could fix install to work with datalad 0.12, but there's a current effort to further change core's clone and to make ria-install superfluous anyway. So for now, this is the easier solution.

Furthermore, procedure (`ria-post-install`) wasn't properly installed. 